### PR TITLE
Adds optional Serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,17 +12,17 @@ license = "MIT/Apache-2.0"
 readme = "README.md"
 
 [features]
-default = ["std-slab", "serde"]
+default = ["std-slab"]
 dot = []
 std-slab = ["slab", "cc-traits/slab"]
-serde = ["dep:serde", "smallvec/serde"]
+serde = ["dep:serde", "smallvec/serde", "serde/derive"]
 
 [dependencies]
 smallvec = {version = "1.8.0"}
 cc-traits = { version = "0.8.0" }
 slab = { version = "0.4.5", optional = true }
 
-serde = { version = "1.0.138", features = ["derive"], optional = true}
+serde = { version = "1.0.138", optional = true}
 
 [dev-dependencies]
 rand = { version = "0.8.5", features = ["small_rng"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,11 @@ dot = []
 std-slab = ["slab", "cc-traits/slab"]
 
 [dependencies]
-smallvec = "1.8.0"
+smallvec = {version = "1.8.0", features = ["serde"]}
 cc-traits = { version = "0.8.0" }
 slab = { version = "0.4.5", optional = true }
+
+serde = { version = "1.0.138", features = ["derive"] }
 
 [dev-dependencies]
 rand = { version = "0.8.5", features = ["small_rng"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,16 +12,17 @@ license = "MIT/Apache-2.0"
 readme = "README.md"
 
 [features]
-default = ["std-slab"]
+default = ["std-slab", "serde"]
 dot = []
 std-slab = ["slab", "cc-traits/slab"]
+serde = ["dep:serde", "smallvec/serde"]
 
 [dependencies]
-smallvec = {version = "1.8.0", features = ["serde"]}
+smallvec = {version = "1.8.0"}
 cc-traits = { version = "0.8.0" }
 slab = { version = "0.4.5", optional = true }
 
-serde = { version = "1.0.138", features = ["derive"], optional = true, default-features = false }
+serde = { version = "1.0.138", features = ["derive"], optional = true}
 
 [dev-dependencies]
 rand = { version = "0.8.5", features = ["small_rng"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ smallvec = {version = "1.8.0", features = ["serde"]}
 cc-traits = { version = "0.8.0" }
 slab = { version = "0.4.5", optional = true }
 
-serde = { version = "1.0.138", features = ["derive"] }
+serde = { version = "1.0.138", features = ["derive"], optional = true, default-features = false }
 
 [dev-dependencies]
 rand = { version = "0.8.5", features = ["small_rng"] }

--- a/src/generic/map/mod.rs
+++ b/src/generic/map/mod.rs
@@ -155,7 +155,7 @@ pub const M: usize = 8;
 #[derive(Clone)]
 pub struct BTreeMap<K, V, C> {
 	/// Allocated and free nodes.
-	nodes: C,
+	pub nodes: C,
 
 	/// Root node id.
 	root: Option<usize>,

--- a/src/generic/node/internal.rs
+++ b/src/generic/node/internal.rs
@@ -9,7 +9,7 @@ use crate::{
 use smallvec::SmallVec;
 use std::{borrow::Borrow, cmp::Ordering};
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "dep:serde")]
 use serde::{Deserialize, Serialize};
 
 /// Underflow threshold.
@@ -21,7 +21,7 @@ const UNDERFLOW: usize = M / 2 - 1;
 ///
 /// A branch is an item followed by child node identifier.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dep:serde", derive(Serialize, Deserialize))]
 pub struct Branch<K, V> {
 	/// Item.
 	pub item: Item<K, V>,
@@ -76,7 +76,7 @@ pub struct InsertionError<K, V> {
 ///
 /// An internal node is a node where each item is surrounded by edges to child nodes.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dep:serde", derive(Serialize, Deserialize))]
 pub struct Internal<K, V> {
 	parent: usize,
 	first_child: usize,

--- a/src/generic/node/internal.rs
+++ b/src/generic/node/internal.rs
@@ -5,9 +5,12 @@ use crate::{
 	},
 	utils::binary_search_min,
 };
-use serde::{Deserialize, Serialize};
+
 use smallvec::SmallVec;
 use std::{borrow::Borrow, cmp::Ordering};
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Underflow threshold.
 ///
@@ -17,7 +20,8 @@ const UNDERFLOW: usize = M / 2 - 1;
 /// Internal node branch.
 ///
 /// A branch is an item followed by child node identifier.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Branch<K, V> {
 	/// Item.
 	pub item: Item<K, V>,
@@ -71,7 +75,8 @@ pub struct InsertionError<K, V> {
 /// Internal node.
 ///
 /// An internal node is a node where each item is surrounded by edges to child nodes.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Internal<K, V> {
 	parent: usize,
 	first_child: usize,

--- a/src/generic/node/internal.rs
+++ b/src/generic/node/internal.rs
@@ -9,7 +9,7 @@ use crate::{
 use smallvec::SmallVec;
 use std::{borrow::Borrow, cmp::Ordering};
 
-#[cfg(feature = "dep:serde")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Underflow threshold.
@@ -21,7 +21,7 @@ const UNDERFLOW: usize = M / 2 - 1;
 ///
 /// A branch is an item followed by child node identifier.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "dep:serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Branch<K, V> {
 	/// Item.
 	pub item: Item<K, V>,
@@ -76,7 +76,7 @@ pub struct InsertionError<K, V> {
 ///
 /// An internal node is a node where each item is surrounded by edges to child nodes.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "dep:serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Internal<K, V> {
 	parent: usize,
 	first_child: usize,

--- a/src/generic/node/internal.rs
+++ b/src/generic/node/internal.rs
@@ -5,6 +5,7 @@ use crate::{
 	},
 	utils::binary_search_min,
 };
+use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use std::{borrow::Borrow, cmp::Ordering};
 
@@ -16,7 +17,7 @@ const UNDERFLOW: usize = M / 2 - 1;
 /// Internal node branch.
 ///
 /// A branch is an item followed by child node identifier.
-#[derive(Clone)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Branch<K, V> {
 	/// Item.
 	pub item: Item<K, V>,
@@ -70,7 +71,7 @@ pub struct InsertionError<K, V> {
 /// Internal node.
 ///
 /// An internal node is a node where each item is surrounded by edges to child nodes.
-#[derive(Clone)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Internal<K, V> {
 	parent: usize,
 	first_child: usize,

--- a/src/generic/node/item.rs
+++ b/src/generic/node/item.rs
@@ -2,24 +2,34 @@ use super::Keyed;
 use std::fmt;
 use std::{cmp::Ordering, mem::MaybeUninit};
 
-use serde::de::Deserializer;
-use serde::ser::{SerializeStruct, Serializer};
-use serde::{Deserialize, Serialize};
+#[cfg(feature = "serde")]
+use serde::{
+	de::{Deserialize, Deserializer},
+	ser::{Serialize, SerializeStruct, Serializer},
+};
 
-#[derive(Deserialize)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub struct Item<K, V> {
 	/// # Safety
 	///
 	/// This field must always be initialized when the item is accessed and/or dropped.
-	#[serde(deserialize_with = "deserialize_maybe_uninit")]
-	#[serde(bound = "K: Deserialize<'de>")]
+	#[cfg_attr(feature = "serde", serde(serialize_with = "serialize_maybe_uninit"))]
+	#[cfg_attr(
+		feature = "serde",
+		serde(deserialize_with = "deserialize_maybe_uninit")
+	)]
+	#[cfg_attr(feature = "serde", serde(bound = "K: Deserialize<'de>"))]
 	key: MaybeUninit<K>,
 
 	/// # Safety
 	///
 	/// This field must always be initialized when the item is accessed and/or dropped.
-	#[serde(deserialize_with = "deserialize_maybe_uninit")]
-	#[serde(bound = "V: Deserialize<'de>")]
+	#[cfg_attr(feature = "serde", serde(serialize_with = "serialize_maybe_uninit"))]
+	#[cfg_attr(
+		feature = "serde",
+		serde(deserialize_with = "deserialize_maybe_uninit")
+	)]
+	#[cfg_attr(feature = "serde", serde(bound = "V: Deserialize<'de>"))]
 	value: MaybeUninit<V>,
 }
 
@@ -35,28 +45,21 @@ impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for Item<K, V> {
 	}
 }
 
-impl<K: Serialize, V: Serialize> Serialize for Item<K, V> {
-	fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-		let mut state = serializer.serialize_struct("Item", 2)?;
-		state.serialize_field("key", self.key())?;
-		state.serialize_field("value", self.value())?;
-		state.end()
-	}
+#[cfg(feature = "serde")]
+fn serialize_maybe_uninit<T: Serialize, S: Serializer>(
+	val: &MaybeUninit<T>,
+	serializer: S,
+) -> Result<S::Ok, S::Error> {
+	let val_ref: &T = unsafe { val.assume_init_ref() };
+	val_ref.serialize(serializer)
 }
 
+#[cfg(feature = "serde")]
 fn deserialize_maybe_uninit<'de, T: Deserialize<'de>, D: Deserializer<'de>>(
 	deserializer: D,
 ) -> Result<MaybeUninit<T>, D::Error> {
 	T::deserialize(deserializer).map(|val| MaybeUninit::new(val))
 }
-
-// impl<'de, K: Deserialize<'de>, V: Deserialize<'de>> Deserialize<'de> for Item<K, V> {
-// 	fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-// 		deserializer.deserialize_struct("Item", 2);
-
-// 		todo!()
-// 	}
-// }
 
 impl<K: Clone, V: Clone> Clone for Item<K, V> {
 	fn clone(&self) -> Self {

--- a/src/generic/node/item.rs
+++ b/src/generic/node/item.rs
@@ -22,7 +22,6 @@ pub struct Item<K, V> {
 		feature = "serde",
 		serde(deserialize_with = "deserialize_maybe_uninit")
 	)]
-	// #[cfg_attr(feature = "serde", serde(bound = "K: Deserialize<'de>"))]
 	key: MaybeUninit<K>,
 
 	/// # Safety
@@ -33,14 +32,13 @@ pub struct Item<K, V> {
 		feature = "serde",
 		serde(deserialize_with = "deserialize_maybe_uninit")
 	)]
-	// #[cfg_attr(feature = "serde", serde(bound = "V: Deserialize<'de>"))]
 	value: MaybeUninit<V>,
 }
 
 impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for Item<K, V> {
 	/// # Safety:
 	///
-	/// Do not call this implementation on items which are not initialized.
+	/// This implementation assumes that the item's key and value are initialized.
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.debug_struct("Item")
 			.field("key", &self.key())

--- a/src/generic/node/item.rs
+++ b/src/generic/node/item.rs
@@ -2,34 +2,40 @@ use super::Keyed;
 use std::fmt;
 use std::{cmp::Ordering, mem::MaybeUninit};
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "dep:serde")]
 use serde::{
 	de::{Deserialize, Deserializer},
 	ser::{Serialize, SerializeStruct, Serializer},
 };
 
-#[cfg_attr(feature = "serde", derive(Deserialize))]
+#[cfg_attr(feature = "dep:serde", derive(Deserialize))]
 pub struct Item<K, V> {
 	/// # Safety
 	///
 	/// This field must always be initialized when the item is accessed and/or dropped.
-	#[cfg_attr(feature = "serde", serde(serialize_with = "serialize_maybe_uninit"))]
 	#[cfg_attr(
-		feature = "serde",
+		feature = "dep:serde",
+		serde(serialize_with = "serialize_maybe_uninit")
+	)]
+	#[cfg_attr(
+		feature = "dep:serde",
 		serde(deserialize_with = "deserialize_maybe_uninit")
 	)]
-	#[cfg_attr(feature = "serde", serde(bound = "K: Deserialize<'de>"))]
+	#[cfg_attr(feature = "dep:serde", serde(bound = "K: Deserialize<'de>"))]
 	key: MaybeUninit<K>,
 
 	/// # Safety
 	///
 	/// This field must always be initialized when the item is accessed and/or dropped.
-	#[cfg_attr(feature = "serde", serde(serialize_with = "serialize_maybe_uninit"))]
 	#[cfg_attr(
-		feature = "serde",
+		feature = "dep:serde",
+		serde(serialize_with = "serialize_maybe_uninit")
+	)]
+	#[cfg_attr(
+		feature = "dep:serde",
 		serde(deserialize_with = "deserialize_maybe_uninit")
 	)]
-	#[cfg_attr(feature = "serde", serde(bound = "V: Deserialize<'de>"))]
+	#[cfg_attr(feature = "dep:serde", serde(bound = "V: Deserialize<'de>"))]
 	value: MaybeUninit<V>,
 }
 
@@ -45,7 +51,7 @@ impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for Item<K, V> {
 	}
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "dep:serde")]
 fn serialize_maybe_uninit<T: Serialize, S: Serializer>(
 	val: &MaybeUninit<T>,
 	serializer: S,
@@ -54,7 +60,7 @@ fn serialize_maybe_uninit<T: Serialize, S: Serializer>(
 	val_ref.serialize(serializer)
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "dep:serde")]
 fn deserialize_maybe_uninit<'de, T: Deserialize<'de>, D: Deserializer<'de>>(
 	deserializer: D,
 ) -> Result<MaybeUninit<T>, D::Error> {

--- a/src/generic/node/item.rs
+++ b/src/generic/node/item.rs
@@ -1,11 +1,12 @@
 use super::Keyed;
+use std::fmt;
 use std::{cmp::Ordering, mem::MaybeUninit};
 
 use serde::de::Deserializer;
 use serde::ser::{SerializeStruct, Serializer};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 pub struct Item<K, V> {
 	/// # Safety
 	///
@@ -20,6 +21,18 @@ pub struct Item<K, V> {
 	#[serde(deserialize_with = "deserialize_maybe_uninit")]
 	#[serde(bound = "V: Deserialize<'de>")]
 	value: MaybeUninit<V>,
+}
+
+impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for Item<K, V> {
+	/// # Safety:
+	///
+	/// Do not call this implementation on items which are not initialized.
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		f.debug_struct("Item")
+			.field("key", &self.key())
+			.field("value", &self.value())
+			.finish()
+	}
 }
 
 impl<K: Serialize, V: Serialize> Serialize for Item<K, V> {

--- a/src/generic/node/leaf.rs
+++ b/src/generic/node/leaf.rs
@@ -8,9 +8,11 @@ use crate::{
 use smallvec::SmallVec;
 use std::borrow::Borrow;
 
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Leaf<K, V> {
 	parent: usize,
 	items: SmallVec<[Item<K, V>; M + 1]>,

--- a/src/generic/node/leaf.rs
+++ b/src/generic/node/leaf.rs
@@ -8,11 +8,11 @@ use crate::{
 use smallvec::SmallVec;
 use std::borrow::Borrow;
 
-#[cfg(feature = "dep:serde")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "dep:serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Leaf<K, V> {
 	parent: usize,
 	items: SmallVec<[Item<K, V>; M + 1]>,

--- a/src/generic/node/leaf.rs
+++ b/src/generic/node/leaf.rs
@@ -8,11 +8,11 @@ use crate::{
 use smallvec::SmallVec;
 use std::borrow::Borrow;
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "dep:serde")]
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dep:serde", derive(Serialize, Deserialize))]
 pub struct Leaf<K, V> {
 	parent: usize,
 	items: SmallVec<[Item<K, V>; M + 1]>,

--- a/src/generic/node/leaf.rs
+++ b/src/generic/node/leaf.rs
@@ -8,7 +8,9 @@ use crate::{
 use smallvec::SmallVec;
 use std::borrow::Borrow;
 
-#[derive(Clone)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Leaf<K, V> {
 	parent: usize,
 	items: SmallVec<[Item<K, V>; M + 1]>,

--- a/src/generic/node/mod.rs
+++ b/src/generic/node/mod.rs
@@ -1,5 +1,8 @@
 use std::{borrow::Borrow, cmp::Ordering, fmt};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 mod addr;
 pub mod internal;
 pub mod item;
@@ -163,12 +166,9 @@ pub struct WouldUnderflow;
 /// the right child of the item if it is removed from an internal node.
 pub type PoppedItem<K, V> = (Offset, Item<K, V>, Option<usize>);
 
-#[cfg(feature = "dep:serde")]
-use serde::{Deserialize, Serialize};
-
 /// B-tree node.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "dep:serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum Node<K, V> {
 	/// Internal node.
 	Internal(InternalNode<K, V>),

--- a/src/generic/node/mod.rs
+++ b/src/generic/node/mod.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 mod addr;
 pub mod internal;
-pub mod item;
+mod item;
 mod leaf;
 
 pub use addr::Address;

--- a/src/generic/node/mod.rs
+++ b/src/generic/node/mod.rs
@@ -163,12 +163,12 @@ pub struct WouldUnderflow;
 /// the right child of the item if it is removed from an internal node.
 pub type PoppedItem<K, V> = (Offset, Item<K, V>, Option<usize>);
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "dep:serde")]
 use serde::{Deserialize, Serialize};
 
 /// B-tree node.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "dep:serde", derive(Deserialize, Serialize))]
 pub enum Node<K, V> {
 	/// Internal node.
 	Internal(InternalNode<K, V>),

--- a/src/generic/node/mod.rs
+++ b/src/generic/node/mod.rs
@@ -163,10 +163,12 @@ pub struct WouldUnderflow;
 /// the right child of the item if it is removed from an internal node.
 pub type PoppedItem<K, V> = (Offset, Item<K, V>, Option<usize>);
 
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// B-tree node.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum Node<K, V> {
 	/// Internal node.
 	Internal(InternalNode<K, V>),

--- a/src/generic/node/mod.rs
+++ b/src/generic/node/mod.rs
@@ -2,7 +2,7 @@ use std::{borrow::Borrow, cmp::Ordering, fmt};
 
 mod addr;
 pub mod internal;
-mod item;
+pub mod item;
 mod leaf;
 
 pub use addr::Address;
@@ -163,8 +163,10 @@ pub struct WouldUnderflow;
 /// the right child of the item if it is removed from an internal node.
 pub type PoppedItem<K, V> = (Offset, Item<K, V>, Option<usize>);
 
+use serde::{Deserialize, Serialize};
+
 /// B-tree node.
-#[derive(Clone)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Node<K, V> {
 	/// Internal node.
 	Internal(InternalNode<K, V>),


### PR DESCRIPTION
I needed to be able to serialize/deserialize individual nodes in my application, so I added support for this in the library.
It can be enabled by using the optional feature also called `"serde"`.

- [x] Serde support for Node and its internals
- [x] Make Serde optional
- [x] Debug implementation for Node and Item

I have not done the final step yet of adding serde Serialize/Deserialize to `BTreeMap` and `BTreeSet` itself, though if you want I can easily add that as well.