### PR TITLE
fixes `drain_filter` and `retain` crash when removing all items

### DIFF
--- a/src/generic/map.rs
+++ b/src/generic/map.rs
@@ -2020,6 +2020,10 @@ where
 	where
 		F: FnMut(&K, &mut V) -> bool,
 	{
+		if self.addr.id.is_nowhere() {
+			return None;
+		}
+		
 		loop {
 			match self.btree.item_mut(self.addr) {
 				Some(item) => {

--- a/src/generic/map.rs
+++ b/src/generic/map.rs
@@ -2020,10 +2020,10 @@ where
 	where
 		F: FnMut(&K, &mut V) -> bool,
 	{
-		if self.addr.id.is_nowhere() {
+		if self.addr.id == usize::MAX {
 			return None;
 		}
-		
+
 		loop {
 			match self.btree.item_mut(self.addr) {
 				Some(item) => {

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -189,6 +189,28 @@ pub fn update() {
 	}
 }
 
+#[test]
+pub fn drain_all() {
+	let mut btree: BTreeMap<usize, usize> = BTreeMap::new();
+
+	for (key, value) in &ITEMS {
+		btree.insert(*key, *value);
+	}
+
+	let mut drained = btree.drain_filter(|_, _| true).collect::<Vec<_>>();
+	assert!(btree.is_empty());
+
+	while let Some((key, value)) = btree.pop_first() {
+		drained.push((key, value));
+	}
+
+	assert_eq!(drained.len(), ITEMS.len());
+
+	for (key, value) in &ITEMS {
+		assert!(drained.contains(&(*key, *value)));
+	}
+}
+
 const ITEMS: [(usize, usize); 100] = [
 	(4223, 5948),
 	(8175, 4629),


### PR DESCRIPTION
`drain_filter` and `retain` crash when removing all items, because when there are no items left the next address and the one in `DrainFilterInner` is `Address::nowhere()`, `DrainFilterInner` calls `item_mut` which calls `node_mut` with the nowhere id and it unwraps a `None`.