### PR TITLE
fix drain_filter halting execution early when remove_at() returns a non-normalized address

### DIFF
--- a/src/generic/map.rs
+++ b/src/generic/map.rs
@@ -2030,9 +2030,16 @@ where
 					let (key, value) = item.as_pair_mut();
 					self.len -= 1;
 					if (*pred)(key, value) {
-						let (item, next_addr) = self.btree.remove_at(self.addr).unwrap();
-						self.addr = next_addr;
-						return Some(item);
+						match self.btree.remove_at(self.addr) {
+							Some((item, next_addr)) => {
+								match self.btree.normalize(next_addr) {
+									Some(addr) => self.addr = addr,
+									None => self.addr = Address::nowhere(),
+								}
+								return Some(item);
+							}
+							None => return None,
+						}
 					} else {
 						self.addr = self.btree.next_item_or_back_address(self.addr).unwrap();
 					}

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -313,3 +313,15 @@ const ITEMS: [(usize, usize); 100] = [
 	(1553, 5964),
 	(4493, 3677),
 ];
+
+#[test]
+fn test_retain() {
+	let mut map = BTreeMap::from_iter((0..100).map(|x| (x, x * 10)));
+	assert_eq!(map.len(), 100);
+
+	map.retain(|&k, _| k % 2 == 0);
+	assert_eq!(map.len(), 50);
+	assert_eq!(map[&2], 20);
+	assert_eq!(map[&4], 40);
+	assert_eq!(map[&6], 60);
+}


### PR DESCRIPTION
Fixes issue #8 